### PR TITLE
Divided BUCKET_PATH variable into two different ones.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.4.2] - 2020-04-29
 ### Changed
-- Environmental variable `BUCKET_PATH` now is divided into `BUCKET_NAME` and `BUCKET_PREFIX` to distinguish the bucket name from an specific path inside that bucket.
+- Environmental variable `BUCKET_PATH` now is divided into `BUCKET_NAME` and `BUCKET_PATH_PREFIX` to distinguish the bucket name from an specific path inside that bucket.
 
 ## [0.4.1] - 2020-04-28
 ### Changed
@@ -45,7 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.1.1] - 2019-11-04
 ### Added
 - Specific version of the project dependencies.
-### Changed
+### Chang ed
 - `ExecutionEnvironment` default value set to **DEV**.
 - Fixed some typos in the code.
 - Change package name to `UDASwissKnife` to avoid conflicts in pipy repository.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Environmental variable `BUCKET_PATH` now is divided into `BUCKET_NAME` and `BUCKET_PREFIX` to distinguish the bucket name from an specific path inside that bucket.
 
 ## [0.4.1] - 2020-04-28
-## Changed
+### Changed
 - Bumped version to 0.4.1 to fix a version problem in PyPI.
 
 ## [0.4.0] - 2020-04-28

--- a/SwissKnife/info/BucketPath.py
+++ b/SwissKnife/info/BucketPath.py
@@ -1,0 +1,22 @@
+from os import environ
+    
+def split_bucket_env() -> (str, str):
+    """Basic function to extract the name of the bucket
+    and the folder structure behind it. As several Google
+    Storage libraries need to know just the name of the 
+    bucket, it's needed to make this division. This 
+    function returns a tuple in which the first element
+    is the bucket name and the second one is a fixed
+    path inside the bucket.
+
+    :return: Bucket name, bucket path prefix
+    :rtype: (str, str)
+    """
+    env_var = environ.get('BUCKET_PATH', "")
+    splitted_env_var = env_var.replace("gs://", "").split("/")
+    
+    base_bucket = splitted_env_var[0]
+    path_preffix = "" if len(splitted_env_var) == 1 else "/".join(splitted_env_var[1:])
+    
+    return base_bucket, path_preffix        
+        

--- a/SwissKnife/info/__init__.py
+++ b/SwissKnife/info/__init__.py
@@ -4,4 +4,4 @@ from SwissKnife.info.BucketPath import split_bucket_env
 from SwissKnife.info.ExecutionEnvironment import ExecutionEnvironment
 
 CURRENT_ENVIRONMENT = ExecutionEnvironment.create(os.environ.get('ENV', None))
-BUCKET_NAME, BUCKET_PREFIX = split_bucket_env()
+BUCKET_NAME, BUCKET_PATH_PREFIX = split_bucket_env()

--- a/SwissKnife/info/__init__.py
+++ b/SwissKnife/info/__init__.py
@@ -1,7 +1,7 @@
 import os
 
-# With this, we can import directly the class without importing the module.
+from SwissKnife.info.BucketPath import split_bucket_env
 from SwissKnife.info.ExecutionEnvironment import ExecutionEnvironment
 
 CURRENT_ENVIRONMENT = ExecutionEnvironment.create(os.environ.get('ENV', None))
-BUCKET_PATH = os.environ.get('BUCKET_PATH', None)
+BUCKET_NAME, BUCKET_PREFIX = split_bucket_env()

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ with open('README.md', encoding='utf-8') as f:
 
 setuptools.setup(
     name='UDASwissKnife',
-    version='0.4.1',
+    version='0.4.2',
     description='Utils and common libraries for Python',
     long_description=long_description,
     long_description_content_type='text/markdown',

--- a/tests/info/test_BUCKET_PATH.py
+++ b/tests/info/test_BUCKET_PATH.py
@@ -8,14 +8,32 @@ import tests.info as test_utils
 
 class Test_BUCKET_PATH(unittest.TestCase):
     
-    def test_is_defined(self):
+    def test_is_defined_with_preffix(self):
         """
         Check if the environment variable is retrieved when it's defined
         """
-        correct_values = ["gs://bucket", "bucket", "_", " "]
-        for val in correct_values:
-            test_utils.set_env_variable("BUCKET_PATH", val)
-            self.assertEqual(val, SwissKnife.info.BUCKET_PATH)
+        full_bucket_path = "gs://bucket-name/some/random/route"
+        bucket_name = "bucket-name"
+        path_preffix = "some/random/route"
+        
+        test_utils.set_env_variable("BUCKET_PATH", full_bucket_path)
+        
+        self.assertEqual(bucket_name, SwissKnife.info.BUCKET_NAME)
+        self.assertEqual(path_preffix, SwissKnife.info.BUCKET_PREFIX)
+
+
+    def test_is_defined_without_preffix(self):
+        """
+        Check if the environment variable is retrieved when it's defined
+        """
+        full_bucket_path = "gs://bucket-name"
+        bucket_name = "bucket-name"
+        path_preffix = ""
+        
+        test_utils.set_env_variable("BUCKET_PATH", full_bucket_path)
+        
+        self.assertEqual(bucket_name, SwissKnife.info.BUCKET_NAME)
+        self.assertEqual(path_preffix, SwissKnife.info.BUCKET_PREFIX)
 
 
     def test_not_defined(self):
@@ -23,4 +41,5 @@ class Test_BUCKET_PATH(unittest.TestCase):
         Check the value when the variable is not defined
         """
         test_utils.delete_env_variable("BUCKET_PATH")
-        self.assertIsNone(SwissKnife.info.BUCKET_PATH)
+        self.assertEqual("", SwissKnife.info.BUCKET_NAME)
+        self.assertEqual("", SwissKnife.info.BUCKET_PREFIX)

--- a/tests/info/test_BUCKET_PATH.py
+++ b/tests/info/test_BUCKET_PATH.py
@@ -19,7 +19,7 @@ class Test_BUCKET_PATH(unittest.TestCase):
         test_utils.set_env_variable("BUCKET_PATH", full_bucket_path)
         
         self.assertEqual(bucket_name, SwissKnife.info.BUCKET_NAME)
-        self.assertEqual(path_preffix, SwissKnife.info.BUCKET_PREFIX)
+        self.assertEqual(path_preffix, SwissKnife.info.BUCKET_PATH_PREFIX)
 
 
     def test_is_defined_without_preffix(self):
@@ -33,7 +33,7 @@ class Test_BUCKET_PATH(unittest.TestCase):
         test_utils.set_env_variable("BUCKET_PATH", full_bucket_path)
         
         self.assertEqual(bucket_name, SwissKnife.info.BUCKET_NAME)
-        self.assertEqual(path_preffix, SwissKnife.info.BUCKET_PREFIX)
+        self.assertEqual(path_preffix, SwissKnife.info.BUCKET_PATH_PREFIX)
 
 
     def test_not_defined(self):
@@ -42,4 +42,4 @@ class Test_BUCKET_PATH(unittest.TestCase):
         """
         test_utils.delete_env_variable("BUCKET_PATH")
         self.assertEqual("", SwissKnife.info.BUCKET_NAME)
-        self.assertEqual("", SwissKnife.info.BUCKET_PREFIX)
+        self.assertEqual("", SwissKnife.info.BUCKET_PATH_PREFIX)


### PR DESCRIPTION
This change was made to clearly distinguish between the name of a bucket and a path inside that bucket were files should be stored.

Right now, if the value of env varaible `BUCKET_PATH` is, for example, `gs://bucket-name/path-inside-bucket`, when calling variable `BUCKET_PATH` of `SwissKnife` the result would be `bucket-name/path-insde-bucket`.

Once this PR is merged, for the same env variable, we'll have two outputs:
- `BUCKET_NAME = bucket-name`
- `BUCKET_PREFIX = path-inside-bucket`

This change is made to handle some constructors of Google Storage libraries, which require just the name of the bucket to work, with no extra paths.