### PR TITLE
Make ExecutionEnvironment JSON serializable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.5.3] - 2020-05-05
 ### Changed
 - Modified `ExecutionEnvironment` Enum so that it is JSON serializable (Issue #8)
   

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
+### Changed
+- Modified `ExecutionEnvironment` Enum so that it is JSON serializable (Issue #8)
+  
 ## [0.5.2] - 2020-04-30
 ### Changed
 - Fixed bug which caused GCloudStreaming files to have twice the bucket prefix.

--- a/SwissKnife/info/ExecutionEnvironment.py
+++ b/SwissKnife/info/ExecutionEnvironment.py
@@ -1,18 +1,22 @@
 from enum import Enum
 
 
-class ExecutionEnvironment(Enum):
+class ExecutionEnvironment(str, Enum):
     """ExutionEnvironment is an Enum that represents a possible ExecutionEnvironment.
     Valid values are PRO, PRE, DEV and TEST. DEV is the default value.
     The static method "create" is the preferred method to create an ExecutionEnvironment because
     it transforms the input to a standard form (lower case). It will return the default value (DEV)
     if an invalid value (or a null value) is provided. 
+    
+    By inhereting both str and Enum we automatically make our enumeration
+    JSON serlizable. It's also needed to annotate the type of the enum
+    values.
     """
 
-    PRO = "pro"
-    PRE = "pre"
-    DEV = "dev"
-    TEST = "test"
+    PRO: str = "pro"
+    PRE: str = "pre"
+    DEV: str = "dev"
+    TEST: str = "test"
     
     @staticmethod
     def create(env_str: str) -> "ExecutionEnvironment":

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ with open('README.md', encoding='utf-8') as f:
 
 setuptools.setup(
     name='UDASwissKnife',
-    version='0.5.2',
+    version='0.5.3',
     description='Utils and common libraries for Python',
     long_description=long_description,
     long_description_content_type='text/markdown',

--- a/tests/info/test_CURRENT_ENVIRONMENT.py
+++ b/tests/info/test_CURRENT_ENVIRONMENT.py
@@ -1,6 +1,7 @@
-import unittest
 import os
 import imp
+import json
+import unittest
 
 import SwissKnife
 import SwissKnife.info
@@ -41,6 +42,12 @@ class Test_CURRENT_ENVIRONMENT(unittest.TestCase):
         for env_value in ["prU", "PRA", "asdfsdf", "unknown"]:
             self._set_current_env(env_value)
             self.assertTrue(SwissKnife.info.CURRENT_ENVIRONMENT.is_dev())
+            
+    def test_is_json_serializable(self):
+        self._set_current_env('TEST')
+        expected = '"test"'
+        actual = json.dumps(SwissKnife.info.CURRENT_ENVIRONMENT)
+        self.assertEqual(expected, actual)
 
 
     def _set_current_env(self, env_str: str):


### PR DESCRIPTION
After implementing this changes, this is what happens when executing the code included in the issue description:

```python
>>> import json
>>> from SwissKnife.info import CURRENT_ENVIRONMENT
>>> json.dumps(CURRENT_ENVIRONMENT)
'"dev"'
```

---
This PR closes Issue #8 