### PR TITLE
Adding calendar function that returns the week number given a timestamp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+#### Added
+- Added a calendar function to get weeks numbers with format `2020W02`
 
 ## [0.6.0] - 2020-05-07
 ### Added

--- a/SwissKnife/avro/AvroTransformer.py
+++ b/SwissKnife/avro/AvroTransformer.py
@@ -1,6 +1,6 @@
 import re
 from typing import Callable
-from avro.types import Record, Variables
+from SwissKnife.avro.types import Record, Variables
 
 
 class NoDefault(object):

--- a/SwissKnife/calendar/WeekUtils.py
+++ b/SwissKnife/calendar/WeekUtils.py
@@ -1,0 +1,21 @@
+from datetime import datetime
+
+
+def get_week_format_from_timestamp(timestamp_millis: int) -> str:
+    """Get week format from timestamp in milliseconds.
+
+    :param timestamp_millis: Timestamp en milliseconds.
+    :type timestamp_millis: int
+    :return: Return in week format {year}W{week}.
+    :rtype: str
+    """
+
+    # This algorithm avoids results like 2019W01 for a 2019-12-31 date
+    # and 2021W53 for a 2021-01-01 date
+
+    date_object = datetime.utcfromtimestamp(int(timestamp_millis) / 1000)
+    calendar = date_object.isocalendar()
+    year = calendar[0]
+    target_week = calendar[1]
+
+    return "{}W{:0>2}".format(year, target_week)

--- a/SwissKnife/calendar/WeekUtils.py
+++ b/SwissKnife/calendar/WeekUtils.py
@@ -2,16 +2,14 @@ from datetime import datetime
 
 
 def get_week_format_from_timestamp(timestamp_millis: int) -> str:
-    """Get week format from timestamp in milliseconds.
+    """Get week format from timestamp in milliseconds. The week number
+    returned will follow ISO-8601 standard
 
-    :param timestamp_millis: Timestamp en milliseconds.
+    :param timestamp_millis: Timestamp in milliseconds.
     :type timestamp_millis: int
-    :return: Return in week format {year}W{week}.
+    :return: Return in week format {year}W{week}. Note that the week will be pad to two digits, e.g: 2020W01
     :rtype: str
     """
-
-    # This algorithm avoids results like 2019W01 for a 2019-12-31 date
-    # and 2021W53 for a 2021-01-01 date
 
     date_object = datetime.utcfromtimestamp(int(timestamp_millis) / 1000)
     calendar = date_object.isocalendar()

--- a/tests/calendar/test_WeekUtils.py
+++ b/tests/calendar/test_WeekUtils.py
@@ -1,0 +1,25 @@
+import unittest
+
+from SwissKnife.calendar.WeekUtils import get_week_format_from_timestamp
+
+
+class TestWeekUtils(unittest.TestCase):
+
+    def test_get_52_week(self):
+        timestamp_millis = 1514678400000  # 2017-12-31 (Sunday)
+        result = get_week_format_from_timestamp(timestamp_millis)
+        self.assertEqual(result, "2017W52")
+
+    def test_get_first_week_with_a_previous_year_day(self):
+        timestamp_millis = 1577709695547  # 2017-12-31 (Sunday)
+        result = get_week_format_from_timestamp(timestamp_millis)
+        self.assertEqual(result, "2020W01")
+
+    def test_get_last_week_with_a_next_year_day(self):
+        timestamp_millis = 1609459200000  # 20121-01-01 (Friday)
+        result = get_week_format_from_timestamp(timestamp_millis)
+        self.assertEqual(result, "2020W53")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/calendar/test_WeekUtils.py
+++ b/tests/calendar/test_WeekUtils.py
@@ -11,12 +11,12 @@ class TestWeekUtils(unittest.TestCase):
         self.assertEqual(result, "2017W52")
 
     def test_get_first_week_with_a_previous_year_day(self):
-        timestamp_millis = 1577709695547  # 2017-12-31 (Sunday)
+        timestamp_millis = 1577709695547  # 2019-12-30 (Sunday)
         result = get_week_format_from_timestamp(timestamp_millis)
         self.assertEqual(result, "2020W01")
 
     def test_get_last_week_with_a_next_year_day(self):
-        timestamp_millis = 1609459200000  # 20121-01-01 (Friday)
+        timestamp_millis = 1609459200000  # 2021-01-01 (Friday)
         result = get_week_format_from_timestamp(timestamp_millis)
         self.assertEqual(result, "2020W53")
 


### PR DESCRIPTION
Added calendar function `get_week_format_from_timestamp` that given a timestamp returns a week number in the following format `2020W02`