### PR TITLE
Add bucket prefix path (resolves #11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved *GCloudStorage.get_storage_complete_file_path* using *os.path.join*.
 - *file_name* is optional in *GCloudStorage.get_storage_complete_file_path*.
 ### Fixed
-- Now *GCloudStorage.list_blobs* can use the BUCKET_PREFIX_PATH. It has an optional param "with_prefix" (True by default).
+- Now *GCloudStorage.list_blobs* can use the BUCKET_PREFIX_PATH. It has an optional param "with_prefix" (True by default). <issue #11>
 
 ## [0.6.2] - 2020-05-28
 #### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.6.3] - 2020-05-xx
+## [0.6.3] - 2020-05-29
 ### Changed
 - Improved `GCloudStorage.get_storage_complete_file_path` using `os.path.join`.
 - `file_name` is optional in `GCloudStorage.get_storage_complete_file_path`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.6.3] - 2020-05-xx
 ### Changed
-- Improved *GCloudStorage.get_storage_complete_file_path* using *os.path.join*.
-- *file_name* is optional in *GCloudStorage.get_storage_complete_file_path*.
+- Improved `GCloudStorage.get_storage_complete_file_path` using `os.path.join`.
+- `file_name` is optional in `GCloudStorage.get_storage_complete_file_path`.
 ### Fixed
-- Now *GCloudStorage.list_blobs* can use the BUCKET_PREFIX_PATH. It has an optional param "with_prefix" (True by default). <issue #11>
+- Now `GCloudStorage.list_blobs` can use the BUCKET_PREFIX_PATH. It has an optional param "with_prefix" (True by default). <issue #11>
 
 ## [0.6.2] - 2020-05-28
 #### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.6.1] - 2020-05-28
+## [0.6.3] - 2020-05-xx
+### Changed
+- Improved *GCloudStorage.get_storage_complete_file_path* using *os.path.join*.
+- *file_name* is optional in *GCloudStorage.get_storage_complete_file_path*.
+### Fixed
+- Now *GCloudStorage.list_blobs* can use the BUCKET_PREFIX_PATH. It has an optional param "with_prefix" (True by default).
+
+## [0.6.2] - 2020-05-28
 #### Added
 - Added a calendar function to get weeks numbers with format `2020W02`
 

--- a/SwissKnife/avro/AvroTransformer.py
+++ b/SwissKnife/avro/AvroTransformer.py
@@ -1,6 +1,6 @@
 import re
 from typing import Callable
-from avro.types import Record, Variables
+from SwissKnife.avro.types import Record, Variables
 
 
 class NoDefault(object):

--- a/SwissKnife/gcloud/GCloudStorage.py
+++ b/SwissKnife/gcloud/GCloudStorage.py
@@ -1,4 +1,5 @@
 import sys
+import os
 import logging
 import google.cloud.storage as gcloud
 
@@ -138,7 +139,7 @@ class GCloudStorage:
         return blob
     
     @staticmethod
-    def get_storage_complete_file_path(file_name: str,
+    def get_storage_complete_file_path(file_name: str=None,
                                        file_path: str=None,
                                        with_bucket: bool=False,
                                        with_prefix: bool=True,
@@ -158,21 +159,24 @@ class GCloudStorage:
         :return: Complete path of a file stored in gcloud
         :rtype: str
         """
-        bucket_name = f'{BUCKET_NAME}/' if with_bucket else ''
-        file_prefix = f'{BUCKET_PATH_PREFIX}/' if with_prefix and BUCKET_PATH_PREFIX else ''
-        path = f'{file_path}/' if file_path else ''
+        bucket_name = BUCKET_NAME if with_bucket else ''
+        file_prefix = BUCKET_PATH_PREFIX if with_prefix and BUCKET_PATH_PREFIX else ''
+        final_file_path = file_path if file_path else ''
         gs_prefix = 'gs://' if with_gs else ''
+        final_file_name = file_name if file_name else ''
         
-        return f'{gs_prefix}{bucket_name}{file_prefix}{path}{file_name}'
+        return os.path.join(gs_prefix, bucket_name, file_prefix, final_file_path, final_file_name)
 
-    def list_blobs(self, storage_path: str) -> "Iterator":
+    def list_blobs(self, storage_path: str, with_prefix : bool = True) -> "Iterator":
         """Lists all the files that exists in the specified path.
         This is similar to GNU's `ls` command. Returns an iterator
         that should be treated later on.
 
-        :param storage_path: Parent path from which files will be listed
+        :param storage_path: Parent path from which files will be listed(without slash at the end)
         :type storage_path: str
         :return: Iterator with blobs contained in the parent path
         :rtype: "Iterator"
         """
-        return self.bucket.list_blobs(prefix=storage_path)
+
+        list_prefix = GCloudStorage.get_storage_complete_file_path(file_path=storage_path, with_prefix=with_prefix, with_gs=False)
+        return self.bucket.list_blobs(prefix=list_prefix)

--- a/SwissKnife/gcloud/GCloudStorage.py
+++ b/SwissKnife/gcloud/GCloudStorage.py
@@ -174,6 +174,8 @@ class GCloudStorage:
 
         :param storage_path: Parent path from which files will be listed(without slash at the end)
         :type storage_path: str
+        :param with_prefix: this adds or not the BUCKET_PREFIX_PATH to the resulting path
+        :type with_prefix: bool
         :return: Iterator with blobs contained in the parent path
         :rtype: "Iterator"
         """

--- a/tests/gcloud/test_GCloudStorage.py
+++ b/tests/gcloud/test_GCloudStorage.py
@@ -92,7 +92,7 @@ class test_GCloudStorage(unittest.TestCase):
                                     file_name)
 
     @mock.patch('SwissKnife.gcloud.GCloudStorage.gcloud')
-    def test_valid_path_in_list_blobs(self, mock_gcloud):
+    def test_valid_path_in_list_blobs_with_prefix(self, mock_gcloud):
 
 
         storage_path = 'random_path'
@@ -109,6 +109,26 @@ class test_GCloudStorage(unittest.TestCase):
         gc.bucket = mocked_bucket
 
         gc.list_blobs(storage_path)
+
+
+    @mock.patch('SwissKnife.gcloud.GCloudStorage.gcloud')
+    def test_valid_path_in_list_blobs_without_prefix(self, mock_gcloud):
+
+
+        storage_path = 'random_path'
+        expected = f'{storage_path}/'
+
+        def assert_path_in_list_blobs(prefix):
+
+            self.assertEqual(prefix, expected)
+
+        mocked_bucket = MagicMock()
+        mocked_bucket.list_blobs = assert_path_in_list_blobs
+        
+        gc = GCloudStorage()
+        gc.bucket = mocked_bucket
+
+        gc.list_blobs(storage_path, with_prefix=False)
 
 
 

--- a/tests/gcloud/test_GCloudStorage.py
+++ b/tests/gcloud/test_GCloudStorage.py
@@ -3,6 +3,7 @@ import imp
 import unittest
 import SwissKnife
 import tests.test_utils as test_utils
+from unittest.mock import MagicMock
 
 from unittest import mock
 from SwissKnife.gcloud.GCloudStorage import GCloudStorage
@@ -47,6 +48,17 @@ class test_GCloudStorage(unittest.TestCase):
                                                               with_prefix=False)
         
         self.assertEqual(expected, result)
+
+    def test_path_without_file_name(self):
+        file_path = 'random/path'
+        expected = f'gs://fancy-bucket/{file_path}/'
+                
+        result = GCloudStorage.get_storage_complete_file_path(
+                                                              file_path=file_path,
+                                                              with_bucket=True,
+                                                              with_prefix=False
+                                                             )
+        self.assertEqual(expected, result)
     
     @mock.patch('SwissKnife.gcloud.GCloudStorage.gcloud')
     def test_correct_data_type_to_upload(self, mock_gcloud):
@@ -62,8 +74,7 @@ class test_GCloudStorage(unittest.TestCase):
                                                           dt,
                                                           file_path,
                                                           file_name))
-        
-        
+
     @mock.patch('SwissKnife.gcloud.GCloudStorage.gcloud')
     def test_incorrect_data_type_to_upload(self, mock_gcloud):
         gc = GCloudStorage()
@@ -79,9 +90,32 @@ class test_GCloudStorage(unittest.TestCase):
                                     dt,
                                     file_path,
                                     file_name)
-    
+
+    @mock.patch('SwissKnife.gcloud.GCloudStorage.gcloud')
+    def test_valid_path_in_list_blobs(self, mock_gcloud):
+
+
+        storage_path = 'random_path'
+        expected = f'{self.bucket_path_prefix}/{storage_path}/'
+
+        def assert_path_in_list_blobs(prefix):
+
+            self.assertEqual(prefix, expected)
+
+        mocked_bucket = MagicMock()
+        mocked_bucket.list_blobs = assert_path_in_list_blobs
+        
+        gc = GCloudStorage()
+        gc.bucket = mocked_bucket
+
+        gc.list_blobs(storage_path)
+
+
+
+
     """
         The rest of methods are not tested in this class, as they are mere
         rewrittings of code provided by Google. This tests would require, 
         as well, to have a working internet connection and a configured SA.
     """
+

--- a/tests/gcloud/test_GCloudStorage.py
+++ b/tests/gcloud/test_GCloudStorage.py
@@ -110,7 +110,6 @@ class test_GCloudStorage(unittest.TestCase):
 
         gc.list_blobs(storage_path)
 
-
     @mock.patch('SwissKnife.gcloud.GCloudStorage.gcloud')
     def test_valid_path_in_list_blobs_without_prefix(self, mock_gcloud):
 


### PR DESCRIPTION
## [0.6.3]
### Changed
- Improved *GCloudStorage.get_storage_complete_file_path* using *os.path.join*.
- *file_name* is optional in *GCloudStorage.get_storage_complete_file_path*.
### Fixed
- Now *GCloudStorage.list_blobs* can use the BUCKET_PREFIX_PATH. It has an optional param "with_prefix" (True by default). <resolves #11>
